### PR TITLE
Removed unnecessary test cases

### DIFF
--- a/tests/web_tests/8.0/test_6.php
+++ b/tests/web_tests/8.0/test_6.php
@@ -1,3 +1,0 @@
-<?php
-
-if ($_SERVER['SERVER_SOFTWARE'] === 'SugarDockerized') echo 'ok';

--- a/tests/web_tests/8.2/test_6.php
+++ b/tests/web_tests/8.2/test_6.php
@@ -1,3 +1,0 @@
-<?php
-
-if ($_SERVER['SERVER_SOFTWARE'] === 'SugarDockerized') echo 'ok';


### PR DESCRIPTION
Due to `Xdebug` restructure, we don't need `prepend` anymore and these testcases are no longer necessary.