### PR TITLE
Handling 'adduser not found' error when building stack v25

### DIFF
--- a/images/permissions/Dockerfile
+++ b/images/permissions/Dockerfile
@@ -1,9 +1,14 @@
 FROM debian:stable-slim
 LABEL maintainer="enrico.simonetti@gmail.com"
 
+RUN apt-get update \
+    && apt-get install -y \
+    adduser
+
 RUN adduser sugar --disabled-password --disabled-login --gecos ""
 
 COPY apps/sugarfixpermissions /usr/local/bin/sugarfixpermissions
 RUN chmod +x /usr/local/bin/sugarfixpermissions
 
 CMD ["/usr/local/bin/sugarfixpermissions"]
+


### PR DESCRIPTION
When I tried building the stack with version 25 in my local environment, I got this error: adduser: not found

That’s because when we use the debian:stable-slim image, adduser isn’t installed by default. So I just installed it, and after adding those lines, the build finished successfully.