### PR TITLE
Fix find -exec terminator in restorefromfile.sh

### DIFF
--- a/utilities/restorefromfile.sh
+++ b/utilities/restorefromfile.sh
@@ -59,8 +59,8 @@ else
 
             if [ -d $TEMP_FOLDER/sql ]
             then
-                find $TEMP_FOLDER/sql -type f -name 'sugar*' ! -name '*triggers*' -exec sh -c 'sql=${1:-:}; x="${2:-:}"; mv "$x" "$sql/sugar.sql"' bash "$TEMP_FOLDER/sql" {} +\;
-                find $TEMP_FOLDER/sql -type f -name '*triggers*' -exec sh -c 'sql=${1:-:}; x="{}"; mv "${2:-:}" "$sql/sugar_triggers.sql"' bash "$TEMP_FOLDER/sql" {} +\;
+                find $TEMP_FOLDER/sql -type f -name 'sugar*' ! -name '*triggers*' -exec sh -c 'sql=${1:-:}; x="${2:-:}"; mv "$x" "$sql/sugar.sql"' bash "$TEMP_FOLDER/sql" {} \;
+                find $TEMP_FOLDER/sql -type f -name '*triggers*' -exec sh -c 'sql=${1:-:}; x="{}"; mv "${2:-:}" "$sql/sugar_triggers.sql"' bash "$TEMP_FOLDER/sql" {} \;
             fi
 
             echo Restoring application files


### PR DESCRIPTION
The terminator '+\;' is parsed by the shell as the literal token '+;', which is neither a valid '+' nor ';' terminator for find -exec, causing 'find: missing argument to -exec' on strict GNU find (e.g., Ubuntu 24.04).

The inline 'sh -c' only references $2, so single-file semantics (\;) is the intended behavior anyway. Fixes #24.