### PR TITLE
Pin permissions container sugar user to UID 1000

### DIFF
--- a/images/permissions/Dockerfile
+++ b/images/permissions/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stable-slim
 LABEL maintainer="enrico.simonetti@gmail.com"
 
-RUN useradd --system --no-create-home --shell /usr/sbin/nologin sugar
+RUN useradd --uid 1000 --no-create-home --shell /usr/sbin/nologin sugar
 
 COPY apps/sugarfixpermissions /usr/local/bin/sugarfixpermissions
 RUN chmod +x /usr/local/bin/sugarfixpermissions


### PR DESCRIPTION
## Summary

The `permissions` image creates the `sugar` user with `useradd --system`, yielding a system UID (100–999). The PHP cron/apache images still create `sugar` with `adduser`, which gives UID 1000. Same name, different UIDs.

`sugarfixpermissions` then chowns `/var/www/html` to the **system** UID, so the cron container's UID-1000 `sugar` cannot write inside `/var/www/html/sugar`. Concrete failure observed in CI: `composer install` inside `tests/web_tests/<ver>/` fails with

```
file_put_contents(./composer.lock): Failed to open stream: Permission denied
```

`vendor/` is never created, and `test_5.php` then fails because `vendor/autoload.php` is missing.

## Change

Switch `useradd --system` to `useradd --uid 1000` in `images/permissions/Dockerfile` so both images agree on UID 1000.

## Why this regressed

The earlier bump of the permissions image from `debian:10.3` to `debian:stable-slim` removed access to `adduser` (a separate package in slim), so the user-creation line was rewritten with `useradd --system`. That introduced the UID drift; the previous `adduser sugar` defaulted to UID 1000.

## Test plan

- [ ] On next tagged run, `tests/web_tests.sh` succeeds end-to-end on sugar25/sugar26 stacks (including `test_5.php`).
- [ ] Local `docker compose up` followed by `composer install` inside the cron container completes without permission errors.